### PR TITLE
Package Name as Object Diagram title

### DIFF
--- a/src/main/java/org/fulib/tools/ObjectDiagrams.java
+++ b/src/main/java/org/fulib/tools/ObjectDiagrams.java
@@ -213,6 +213,7 @@ public class ObjectDiagrams
       this.makeNodes(relevantObjects, idMap, reflectorMap, diagramObjects, edges);
 
       final ST st = TEMPLATE_GROUP.getInstanceOf("objectDiagram");
+      st.add("title", packageName);
       st.add("objects", diagramObjects);
       st.add("edges", edges);
       final String dotString = st.render();

--- a/src/main/resources/org/fulib/tools/templates/objectDiagram.stg
+++ b/src/main/resources/org/fulib/tools/templates/objectDiagram.stg
@@ -1,7 +1,7 @@
 delimiters "$", "$"
 
-objectDiagram(objects, edges) ::= <<
-digraph H {
+objectDiagram(title, objects, edges) ::= <<
+digraph "$title$" {
     $objects:object(); separator="\n"$
     $edges:edge(); separator="\n"$
 }


### PR DESCRIPTION
## Improvements

* The title of object diagrams is now the package name of the displayed objects' types.