### PR TITLE
Fix HTML escaping in Class Diagrams

### DIFF
--- a/src/main/java/org/fulib/tools/ClassDiagrams.java
+++ b/src/main/java/org/fulib/tools/ClassDiagrams.java
@@ -9,6 +9,7 @@ import org.fulib.classmodel.Clazz;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupFile;
+import org.stringtemplate.v4.StringRenderer;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,6 +23,11 @@ public class ClassDiagrams
 {
    private static final STGroup TEMPLATE_GROUP = new STGroupFile(
       ClassDiagrams.class.getResource("templates/classDiagram.stg"));
+
+   static
+   {
+      TEMPLATE_GROUP.registerRenderer(String.class, new StringRenderer());
+   }
 
    private double scale = 1;
 

--- a/src/main/java/org/fulib/tools/ClassDiagrams.java
+++ b/src/main/java/org/fulib/tools/ClassDiagrams.java
@@ -2,6 +2,7 @@ package org.fulib.tools;
 
 import guru.nidi.graphviz.engine.Format;
 import guru.nidi.graphviz.engine.Graphviz;
+import guru.nidi.graphviz.engine.GraphvizException;
 import org.fulib.classmodel.AssocRole;
 import org.fulib.classmodel.ClassModel;
 import org.fulib.classmodel.Clazz;
@@ -124,16 +125,20 @@ public class ClassDiagrams
     */
    public String dump(ClassModel model, String diagramFileName, Format format)
    {
+      final ST classDiagram = TEMPLATE_GROUP.getInstanceOf("classDiagram");
+      classDiagram.add("classModel", model);
+      classDiagram.add("roles", getRolesWithoutOthers(model));
+      final String dotString = classDiagram.render();
+
       try
       {
-         final ST classDiagram = TEMPLATE_GROUP.getInstanceOf("classDiagram");
-         classDiagram.add("classModel", model);
-         classDiagram.add("roles", getRolesWithoutOthers(model));
-         final String dotString = classDiagram.render();
-
          Graphviz.fromString(dotString).scale(this.getScale()).render(format).toFile(new File(diagramFileName));
 
          return diagramFileName;
+      }
+      catch (GraphvizException graphvizException)
+      {
+         throw new RuntimeException("Graphviz rendering failed for dot string from class model:\n" + dotString, graphvizException);
       }
       catch (IOException e)
       {


### PR DESCRIPTION
## Bugfixes

* Fixed an exception when attempting to generate class diagrams for models with attributes of generic types. #21 

Closes #21 